### PR TITLE
chore: add cors

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-postdeploy: python manage.py migrate && python manage.py import_page_templates && python manage.py update_index
+postdeploy: python manage.py migrate && python manage.py import_dsfr_pictograms && python manage.py import_page_templates && python manage.py update_index
 web: gunicorn config.wsgi --log-file -

--- a/config/settings.py
+++ b/config/settings.py
@@ -37,6 +37,12 @@ DEBUG = True if os.getenv("DEBUG") == "True" else False
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "127.0.0.1, localhost").replace(" ", "").split(",")
 
+CORS_ORIGIN_ALLOW_ALL = False
+CORS_ORIGIN_WHITELIST = []
+for host in ALLOWED_HOSTS:
+  CORS_ORIGIN_WHITELIST.append("https://" + host)
+  CORS_ORIGIN_WHITELIST.append("http://" + host)
+
 HOST_URL = os.getenv("HOST_URL", "localhost")
 
 INTERNAL_IPS = [
@@ -82,6 +88,7 @@ INSTALLED_APPS = [
     "blog",
     "events",
     "forms",
+    "corsheaders"
 ]
 
 # Only add these on a dev machine, outside of tests
@@ -102,6 +109,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
 ]
 
 # Only add this on a dev machine, outside of tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ beautifulsoup4 = "^4.12.3"
 django-taggit = "^5.0.1"
 wagtail-localize = "^1.9"
 icalendar = "^5.0.13"
+django-cors-headers = "^4.6.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## 🎯 Objectif

Cette PR rajoute les cors afin de requêter l'API Wagtails depuis un domaine différent que celui du cms.

C'est un ajout de fonctionnalité

## 🔍 Implémentation

- Ajout de la lib django-cors-headers
- Modification du fichier `settings.py` afin d'ajouter les `ALLOWED_HOSTS` dans les cors